### PR TITLE
Add 10 year lifetime for theme cookie

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -11,7 +11,7 @@ function changeTheme(theme) {
             $(document.body).css("background-color", "black").css("color", "white");
             break;
     }
-    $.cookie("theme", theme);
+    $.cookie("theme", theme, {expires: 3650});
 }
 
 $(document).ready(function() {

--- a/src/header.js
+++ b/src/header.js
@@ -11,7 +11,9 @@ function changeTheme(theme) {
             $(document.body).css("background-color", "black").css("color", "white");
             break;
     }
-    $.cookie("theme", theme, {expires: 3650});
+    if ($.cookie("theme") === undefined) {
+        $.cookie("theme", theme, {expires: 3650});
+    }
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
Fixes #1. [Per the cookie specification](https://tools.ietf.org/html/rfc6265#section-4.1.2.2), cookies are to have expiry dates set for them. (Otherwise they are session cookies, which expire when the browsing session ends) Set expiry date for theme cookie to be off in the distant future.