### PR TITLE
Move tasks copying from gulpfile to separate post-install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "hacka-news for the web",
   "main": "app.js",
   "scripts": {
-    "postinstall": "cd semantic && gulp build && cd .. && npm run dl-vendors && npm run build",
+    "postinstall": "node post-install.js && cd semantic && gulp build && cd .. && npm run dl-vendors && npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node app.js",
     "build": "webpack",

--- a/post-install.js
+++ b/post-install.js
@@ -1,0 +1,13 @@
+var fs = require('fs-extra'),
+    path = require('path');
+
+/* Copy tasks from node_modules */
+
+try {
+    var stat = fs.statSync(path.join(__dirname, './tasks'));
+    console.log('"tasks" folder already exists. Continuing...');
+} catch (e) {
+    console.log('Copying "tasks" folder from "node_modules/semantic-ui/tasks"');
+    fs.copySync(path.join(__dirname, './node_modules/semantic-ui/tasks'), path.join(__dirname, './semantic/tasks'));
+    console.log('Copying done! Continuing...');
+}

--- a/post-install.js
+++ b/post-install.js
@@ -3,11 +3,14 @@ var fs = require('fs-extra'),
 
 /* Copy tasks from node_modules */
 
+var tasksPath = "./node_modules/semantic-ui/tasks";
+var tasksDest = "./semantic/tasks";
+
 try {
-    var stat = fs.statSync(path.join(__dirname, './tasks'));
+    var stat = fs.statSync(path.join(__dirname, tasksDest));
     console.log('"tasks" folder already exists. Continuing...');
 } catch (e) {
-    console.log('Copying "tasks" folder from "node_modules/semantic-ui/tasks"');
-    fs.copySync(path.join(__dirname, './node_modules/semantic-ui/tasks'), path.join(__dirname, './semantic/tasks'));
+    console.log('Copying "tasks" folder from "' + tasksPath + '"');
+    fs.copySync(path.join(__dirname, tasksPath), path.join(__dirname, tasksDest));
     console.log('Copying done! Continuing...');
 }

--- a/semantic/gulpfile.js
+++ b/semantic/gulpfile.js
@@ -3,21 +3,6 @@
 *******************************/
 
 var
-    fs           = require('fs-extra'),
-    path         = require('path');
-
-/* Copy tasks from node_modules */
-
-try {
-    var stat = fs.statSync(path.join(__dirname, './tasks'));
-    console.log('"tasks" folder already exists. Continuing...');
-} catch (e) {
-    console.log('Copying "tasks" folder from "node_modules/semantic-ui/tasks"');
-    fs.copySync(path.join(__dirname, '../node_modules/semantic-ui/tasks'), path.join(__dirname, './tasks'));
-    console.log('Copying done! Continuing...');
-}
-
-var
   gulp         = require('gulp-help')(require('gulp')),
 
   // read user config to know what task to load
@@ -44,6 +29,7 @@ var
   buildRTL     = require('./tasks/rtl/build'),
   watchRTL     = require('./tasks/rtl/watch')
 ;
+
 
 /*******************************
              Tasks


### PR DESCRIPTION
Every time `npm install` is run, a new copy of Semantic UI's default gulpfile.js is downloaded and replaces the version of the gulpfile currently checked in. I thought it would be better just to move this out and run it immediately after install.