### PR TITLE
Override UI Menu Item position property to static

### DIFF
--- a/semantic/src/site/collections/menu.overrides
+++ b/semantic/src/site/collections/menu.overrides
@@ -2,6 +2,10 @@
          Site Overrides
 *******************************/
 
+.ui.menu .item {
+    position: static;
+}
+
 .orange {
     background-color: #F2711C !important;
     color: black;


### PR DESCRIPTION
Fixes #11. Setting position property to ```static``` instead of ```relative``` appears to remove the outline around title menu item as well as menu buttons, without any impact on the menu itself.