### PR TITLE
Improve selected style for theme items in menu bar (both desktop and mobile)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,3 +16,12 @@
         margin: 5em 1em 0em 1em;
     }
 }
+
+/* Mobile Menu Bar */
+.theme-item {
+    cursor: pointer;
+}
+
+.theme-item.selected > .ui.label {
+    border: 1px solid white !important;
+}

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -26,6 +26,7 @@ function changeTheme(theme) {
         theme = "regular";
     }
     $(".ui.themeable:not(.ui.label)").addClass(getThemeColor(theme));
+    $(`.theme-item`).removeClass("selected");
     switch (theme) {
         case "regular":
             $(".ui.themeable:not(.ui.label), .ui.sub-themeable:not(.ui.label)").removeClass("inverted");
@@ -48,6 +49,7 @@ function changeTheme(theme) {
             $(".back-layer")[0].style.setProperty("color", "white");
             break;
     }
+    $(`#${theme}.theme-item`).addClass("selected");
     $.cookie("theme", theme, {expires: 3650});
 }
 

--- a/views/options-menu.ejs
+++ b/views/options-menu.ejs
@@ -12,19 +12,19 @@
 <% if ( type == "mobile" ) { %>
 <div class="item">
 <% } %>
-  <div class="item" id="regular">
+  <div class="item theme-item" id="regular">
     <div class="ui orange empty label"></div>
     Regular
   </div>
-  <div class="item" id="night">
+  <div class="item theme-item" id="night">
     <div class="ui darkorange empty label"></div>
     Night
   </div>
-  <div class="item" id="midnight">
+  <div class="item theme-item" id="midnight">
     <div class="ui black empty label"></div>
     Midnight
   </div>
-  <div class="item" id="hacktoberfest">
+  <div class="item theme-item" id="hacktoberfest">
     <div class="ui hacktoberfest empty label"></div>
     Hacktoberfest
   </div>


### PR DESCRIPTION
- On desktop, current theme will appear selected on page load
- On mobile, theme items have pointer cursor and have white outline around label portion

![Screenshot 2021-10-04 at 21-24-20 hacka-news](https://user-images.githubusercontent.com/3276350/135946257-31db169d-e820-475b-baad-b66957e48143.png)
![Screenshot 2021-10-04 at 21-27-20 hacka-news](https://user-images.githubusercontent.com/3276350/135946258-620de3a3-5026-4df0-a2c5-e7a93dfcab87.png)
